### PR TITLE
Add 1.9.3 compatibility

### DIFF
--- a/bin/git_hooks
+++ b/bin/git_hooks
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# -*- encoding : utf-8 -*-
 
 require_relative '../lib/git_hooks/cli'
 

--- a/git-hooks.gemspec
+++ b/git-hooks.gemspec
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/lib/git-hooks.rb
+++ b/lib/git-hooks.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'equalizer'
 require 'yaml'
 

--- a/lib/git_hooks/cli.rb
+++ b/lib/git_hooks/cli.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'thor'
 
 require_relative '../git-hooks'

--- a/lib/git_hooks/config_file.rb
+++ b/lib/git_hooks/config_file.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   class ConfigFile
     def initialize(path)

--- a/lib/git_hooks/configurations.rb
+++ b/lib/git_hooks/configurations.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'forwardable'
 
 module GitHooks
@@ -6,12 +7,12 @@ module GitHooks
 
     attr_reader :config_file, :git_repository
 
-    def initialize(
-      config_file: default_config_file,
-      git_repository: default_git_repository
-    )
-      @config_file = config_file
-      @git_repository = git_repository
+    def initialize(options = {})
+      options[:config_file] ||=  default_config_file
+      options[:git_repository] ||= default_git_repository
+
+      @config_file = options[:config_file]
+      @git_repository = options[:git_repository]
 
       super(config_file)
     end

--- a/lib/git_hooks/exceptions.rb
+++ b/lib/git_hooks/exceptions.rb
@@ -1,1 +1,2 @@
+# -*- encoding : utf-8 -*-
 require_relative 'exceptions/missing_hooks'

--- a/lib/git_hooks/exceptions/missing_hooks.rb
+++ b/lib/git_hooks/exceptions/missing_hooks.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   module Exceptions
     class MissingHook < RuntimeError

--- a/lib/git_hooks/git.rb
+++ b/lib/git_hooks/git.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'forwardable'
 
 module GitHooks

--- a/lib/git_hooks/pre_commit.rb
+++ b/lib/git_hooks/pre_commit.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require_relative 'pre_commit/prevent_master'
 require_relative 'pre_commit/rspec'
 require_relative 'pre_commit/rubocop'

--- a/lib/git_hooks/pre_commit/prevent_master.rb
+++ b/lib/git_hooks/pre_commit/prevent_master.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   module PreCommit
     class PreventMaster

--- a/lib/git_hooks/pre_commit/rspec.rb
+++ b/lib/git_hooks/pre_commit/rspec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   module PreCommit
     class Rspec

--- a/lib/git_hooks/pre_commit/rubocop.rb
+++ b/lib/git_hooks/pre_commit/rubocop.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   module PreCommit
     class Rubocop

--- a/lib/git_hooks/rspec_executor.rb
+++ b/lib/git_hooks/rspec_executor.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   class RspecExecutor
     def errors?

--- a/lib/git_hooks/rubocop_validator.rb
+++ b/lib/git_hooks/rubocop_validator.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   class RubocopValidator
     def errors?(files)

--- a/lib/git_hooks/version.rb
+++ b/lib/git_hooks/version.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   VERSION = '0.1.0'
 end

--- a/spec/git_hooks/config_file_spec.rb
+++ b/spec/git_hooks/config_file_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   describe ConfigFile do
     subject(:config) { described_class.new(path) }

--- a/spec/git_hooks/configurations_spec.rb
+++ b/spec/git_hooks/configurations_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   describe Configurations do
     subject(:configurations) { described_class.new }

--- a/spec/git_hooks/git_spec.rb
+++ b/spec/git_hooks/git_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   describe Git do
     subject(:git) { described_class.new(working_folder) }
@@ -44,7 +45,7 @@ module GitHooks
       end
 
       it 'merges added and modified' do
-        is_expected.to eq(%i(foo bar))
+        is_expected.to eq([:foo, :bar])
       end
     end
 

--- a/spec/git_hooks/pre_commit/prevent_master_spec.rb
+++ b/spec/git_hooks/pre_commit/prevent_master_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   module PreCommit
     describe PreventMaster do

--- a/spec/git_hooks/pre_commit/rspec_spec.rb
+++ b/spec/git_hooks/pre_commit/rspec_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   module PreCommit
     describe Rspec do

--- a/spec/git_hooks/pre_commit/rubocop_spec.rb
+++ b/spec/git_hooks/pre_commit/rubocop_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   module PreCommit
     describe Rubocop do

--- a/spec/git_hooks/rspec_executor_spec.rb
+++ b/spec/git_hooks/rspec_executor_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   describe RspecExecutor do
     subject(:rspec_executor) { described_class.new }

--- a/spec/git_hooks/rubocop_validator_spec.rb
+++ b/spec/git_hooks/rubocop_validator_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module GitHooks
   describe RubocopValidator do
     subject(:rubocop_validator) { described_class.new }

--- a/spec/git_hooks_spec.rb
+++ b/spec/git_hooks_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 describe GitHooks do
   describe '#validate_hooks!' do
     subject { -> { described_class.validate_hooks! } }
@@ -61,18 +62,21 @@ describe GitHooks do
   end
 
   describe 'configurations=' do
-    subject(:set_configurations) { described_class.configurations = configs }
+    subject(:set_configurations) do
+      described_class.configurations = other_configs
+    end
 
     let(:configs) { instance_double(GitHooks::Configurations) }
+    let(:other_configs) { instance_double(GitHooks::Configurations) }
 
     before do
-      allow(GitHooks::Configurations).to receive(:new).and_return(nil)
+      described_class.configurations = configs
     end
 
     it 'updates configurations' do
       expect { set_configurations }.to change {
         GitHooks.configurations
-      }.to(configs)
+      }.from(configs).to(other_configs)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require_relative '../lib/git-hooks'
 
 def fixture_path(filename)


### PR DESCRIPTION
As a friend asked, I made this compatible with 1.9.3 (or I supose to make
it). I just dont know if it's a good idea.

By one side, 1.9.3 is a supported ruby version ATM (probably it will be for some
time).

By the other, I really would like to ignore this old version.

To let things more complecated, the company I work have many 1.9.3
projects.

I really dont know what to do :(

what do you guys think? @leafac 
