### PR TITLE
Only check ruby files on debugger validation

### DIFF
--- a/lib/git_hooks/pre_commit/prevent_debugger.rb
+++ b/lib/git_hooks/pre_commit/prevent_debugger.rb
@@ -12,23 +12,31 @@ module GitHooks
       end
 
       def validate
-        abort 'Prevented to commit with debugger' if any_debugger?
+        abort(
+          "Prevented commit with debugger in #{files_with_debugger}"
+        ) if files_with_debugger.any?
       end
 
       private
 
-      def any_debugger?
-        git_repository.added_or_modified.any? do |file_name|
-          File.read(file_name) =~ debugger_regex
-        end
+      def files_with_debugger
+        git_repository
+          .added_or_modified
+          .select(&ruby_files)
+          .select(&contains_debugger?)
+      end
+
+      def ruby_files
+        -> (file) { File.extname(file) == '.rb' }
+      end
+
+      def contains_debugger?
+        -> (file) { File.read(file) =~ debugger_regex }
       end
 
       def debugger_regex
         Regexp.union(
-          %w(
-            binding.pry binding.remote_pry
-            save_and_open_page debugger
-          )
+          %w(binding.pry binding.remote_pry save_and_open_page debugger)
         )
       end
     end

--- a/spec/git_hooks/pre_commit/prevent_debugger_spec.rb
+++ b/spec/git_hooks/pre_commit/prevent_debugger_spec.rb
@@ -36,6 +36,12 @@ module GitHooks
 
             it { is_expected.to raise_error(SystemExit) }
           end
+
+          context 'when the modified file is not a ruby code file' do
+            let(:files) { ['some_text_file.txt'] }
+
+            it { is_expected.not_to raise_error }
+          end
         end
       end
 


### PR DESCRIPTION
There is no need to check non-ruby files for debugger regexps.