### PR TITLE
Allow user to specify Ruby executable when installing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,24 @@ application's start-up code (e.g. `config/environments/development.rb` or
 GitHooks.validate_hooks!
 ```
 
-This will force `git_hooks` installation before your application's start.
+This will force `git_hooks` installation before you can run your application. Be
+sure not to call `GitHooks#validate_hooks!` on production environments though!
+
+### Problems with ruby version
+
+If you run `git` under other systems such as `gitk` or Emacs' `Magit`, you may
+encounter problems with the ruby version being used to run `GitHooks`. This
+happens because those applications don't source the `~/.bashrc` file, which is
+required by ruby version managers such as `Rbenv` and `Rvm`.
+
+In order to fix this problem, you can install the hooks by passing your ruby
+path to the `--ruby_path` option. For example:
+
+```sh
+$ git_hooks install pre-commit --ruby_path `which ruby`
+```
+
+You can also manually edit the `.git/hooks/{hook-name}` file though.
 
 ## Contributing
 

--- a/lib/git_hooks/cli.rb
+++ b/lib/git_hooks/cli.rb
@@ -6,13 +6,15 @@ module GitHooks
   class CLI < Thor
     desc 'install HOOK', 'Install some hook'
     option :force, type: :boolean
+    option :ruby_path, type: :string
     long_desc <<-LONGDESC
       Install some hook:
 
       $ git_hooks install pre-commit
     LONGDESC
     def install(hook)
-      GitHooks::Installer.new(hook).install(options[:force])
+      GitHooks::Installer.new(hook, options[:ruby_path])
+        .install(options[:force])
     end
 
     desc 'Init GitHooks on current folder', 'Create a configuration file'

--- a/lib/git_hooks/exceptions/unknown_hook_present.rb
+++ b/lib/git_hooks/exceptions/unknown_hook_present.rb
@@ -1,8 +1,11 @@
 module GitHooks
   module Exceptions
-    class UnknowHookPresent < RuntimeError
+    class UnknownHookPresent < RuntimeError
       def initialize(hook)
-        super "There is a unknown #{hook} hook. If you are sure, use --force."
+        super <<-HEREDOC
+There is already a #{hook} hook installed.
+If you want to override it, use the --force option.
+HEREDOC
       end
     end
   end

--- a/spec/git_hooks/installer_spec.rb
+++ b/spec/git_hooks/installer_spec.rb
@@ -3,68 +3,55 @@ describe GitHooks::Installer do
 
   let(:hook) { 'pre-commit' }
 
-  let(:hook_real_path) do
+  let(:hook_template_path) do
     File.join(GitHooks.base_path, 'hook.sample')
   end
 
-  let(:absolute_path) do
-    File.join(GitHooks.base_path, '.git', 'hooks', hook)
+  let(:hook_path) do
+    File.join('.git', 'hooks', hook)
   end
 
   let(:git_hook_path) { ".git/hooks/#{hook}" }
+  let(:file) { instance_double(File, write: true) }
+
+  before do
+    allow(File).to receive(:open).and_return(file)
+    allow(FileUtils).to receive(:chmod).and_return(true)
+  end
 
   describe '#install' do
     subject(:install) { installer.install }
 
+    let(:installed?) { false }
+
     before do
-      allow(installer).to receive(:installed?).and_return(false)
-      allow(FileUtils).to receive(:symlink).and_return(true)
+      allow(installer).to receive(:installed?)
+        .and_return(installed?)
     end
 
-    it 'creates symlink' do
-      expect(FileUtils)
-        .to receive(:symlink)
-        .with(hook_real_path, git_hook_path, force: false)
+    it 'creates a new file' do
+      expect(File).to receive(:open)
+        .with(hook_path, 'w')
+
+      expect(file).to receive(:write)
+        .with(/GitHooks.execute_pre_commits/)
 
       install
     end
 
     it { is_expected.to be_truthy }
 
-    context 'when there is a unknown hook' do
-      before do
-        allow(FileUtils).to receive(:symlink).and_raise(Errno::EEXIST)
-      end
-
-      it 'raises an error' do
-        expect { install }.to raise_error(
-          GitHooks::Exceptions::UnknowHookPresent
-        )
-      end
-    end
-
     context 'when there is a unknown hook but I want to force installation' do
-      subject(:install) { installer.install true }
+      subject(:install) { installer.install(true) }
+
+      let(:installed?) { true }
 
       it 'creates symlink with force option' do
-        expect(FileUtils)
-          .to receive(:symlink)
-          .with(hook_real_path, git_hook_path, force: true)
+        expect(File).to receive(:open)
+          .with(hook_path, 'w')
 
-        install
-      end
-
-      it { is_expected.to be_truthy }
-    end
-
-    context 'when hook is already installed' do
-      before do
-        allow(installer).to receive(:installed?).and_return(true)
-      end
-
-      it 'does not create symlink' do
-        expect(FileUtils)
-          .to_not receive(:symlink)
+        expect(file).to receive(:write)
+          .with(/GitHooks.execute_pre_commits/)
 
         install
       end
@@ -76,29 +63,22 @@ describe GitHooks::Installer do
   describe '#installed?' do
     subject(:installed?) { installer.installed? }
 
-    let(:symlink?) { true }
-
     before do
-      allow(File).to receive(:symlink?).and_return(symlink?)
-      allow(File).to receive(:realpath).and_return(hook_real_path)
-    end
-
-    it 'validates file is a symlink' do
-      expect(File).to receive(:symlink?).with(absolute_path)
-      installed?
+      allow(File).to receive(:read)
+        .and_return('GitHooks.execute_pre_commits')
     end
 
     it { is_expected.to be_truthy }
 
-    context 'when file is not a symlink' do
-      let(:symlink?) { false }
-
-      it { is_expected.to be_falsy }
+    it do
+      expect(File).to receive(:exist?).with(hook_path)
+      installed?
     end
 
-    context 'when is not the GitHooks file' do
+    context 'when the hook does not validate pre_commits' do
       before do
-        allow(File).to receive(:realpath).and_return('/tmp/foo')
+        allow(File).to receive(:read)
+          .and_return('echo yolo')
       end
 
       it { is_expected.to be_falsy }

--- a/spec/git_hooks/installer_spec.rb
+++ b/spec/git_hooks/installer_spec.rb
@@ -63,12 +63,17 @@ describe GitHooks::Installer do
   describe '#installed?' do
     subject(:installed?) { installer.installed? }
 
+    let(:exists?) { true }
+
     before do
+      allow(File).to receive(:exist?).and_return(exists?)
       allow(File).to receive(:read)
         .and_return('GitHooks.execute_pre_commits')
     end
 
-    it { is_expected.to be_truthy }
+    it do
+      is_expected.to be_truthy
+    end
 
     it do
       expect(File).to receive(:exist?).with(hook_path)
@@ -80,6 +85,12 @@ describe GitHooks::Installer do
         allow(File).to receive(:read)
           .and_return('echo yolo')
       end
+
+      it { is_expected.to be_falsy }
+    end
+
+    context 'when the hook file does not exist' do
+      let(:exists?) { false }
 
       it { is_expected.to be_falsy }
     end


### PR DESCRIPTION
This commit allows a user to specify the ruby executable when installing
hooks. This fixes many problems when running git under other
applications such as `gitk` and Emacs' `magit`.